### PR TITLE
fix(qmake): 修复 Qt 5.15.2 MSVC 下 qmake 全量构建

### DIFF
--- a/Examples/Gallery/Gallery.pro
+++ b/Examples/Gallery/Gallery.pro
@@ -75,7 +75,7 @@ HEADERS += $$PWD/mainwindow.h \
 FORMS   += $$PWD/mainwindow.ui
 
 win32 {
-    LIBS += -ldbghelp -liphlpapi -lpdh
+    LIBS += -ldbghelp -liphlpapi -lpdh -luser32
     SOURCES += $$PWD/applanguage.cpp
     HEADERS += $$PWD/applanguage.h
 
@@ -83,7 +83,7 @@ win32 {
     #   lupdate Gallery.pro && python tools/fill_en_ts.py && lrelease translations/Gallery_en_US.ts -qm translations/Gallery_en_US.qm
     TRANSLATIONS += translations/Gallery_en_US.ts
 
-    LRELEASE = $$clean_path($$[QT_INSTALL_BINS]/lrelease.exe)
+    LRELEASE = $$shell_path($$[QT_INSTALL_BINS]/lrelease.exe)
 
     gallery_qm.target = $$shell_path($$PWD/translations/Gallery_en_US.qm)
     gallery_qm.commands = $$quote($$LRELEASE) $$quote($$PWD/translations/Gallery_en_US.ts) -qm $$quote($$PWD/translations/Gallery_en_US.qm)

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ git clone --recursive https://github.com/XHY-ChuJian/FluentUIStyle.git
 
 - `BUILD_LIBRARY`：编译样式库（默认 ON）
 - `BUILD_PLUGIN`：编译 Qt Style 插件（默认 ON）
-- `BUILD_GALLERY`：编译 Gallery（默认 ON）
+- `BUILD_EXAMPLES`：编译示例程序（默认 ON，包含 Gallery 与 Win11Clock）
 - `EXWIDGETS_BUILD_FRAMELESS`：编译 `ExWidgets::Frameless` 并引入 QWindowKit（Qt ≥ 5.15.2 默认 **ON**，旧版 Qt 默认 **OFF**）
 - `FLUENTUI3STYLE_COPY_TO_QT_DIR`：构建后将插件复制到 Qt 的 `plugins/styles`（默认 **ON**）
 

--- a/common.pri
+++ b/common.pri
@@ -14,8 +14,14 @@ win32-msvc {
     }
 }
 
-DESTDIR_BIN = $$OUT_PWD/../bin
-DESTDIR_LIB = $$OUT_PWD/../lib
+# 由顶层 subdirs 工程写入的构建根目录；存在时保证嵌套子项目也输出到同一个 bin/lib
+!isEmpty(FLUENT_BUILD_ROOT) {
+    DESTDIR_BIN = $$FLUENT_BUILD_ROOT/bin
+    DESTDIR_LIB = $$FLUENT_BUILD_ROOT/lib
+} else {
+    DESTDIR_BIN = $$OUT_PWD/../bin
+    DESTDIR_LIB = $$OUT_PWD/../lib
+}
 
 isEmpty(PREFIX) {
     PREFIX = $$PWD/install

--- a/fluentw3uistyle.pro
+++ b/fluentw3uistyle.pro
@@ -1,3 +1,6 @@
+FLUENT_BUILD_ROOT = $$OUT_PWD
+cache(FLUENT_BUILD_ROOT, set)
+
 TEMPLATE = subdirs
 CONFIG += ordered
 
@@ -8,22 +11,21 @@ CONFIG += build_gallery
 SUBDIRS += ExWidgets
 
 build_library {
-    fluentui3style.subdir = FluentUI3Style
-    fluentui3style.file = FluentUI3Style.pro
+    FluentUI3Style.file = fluentui3style/FluentUI3Style.pro
     SUBDIRS += FluentUI3Style
 }
 
 build_plugin {
     win32 {
-        fluentui3styleplugin.subdir = FluentUI3Style/plugin
-        SUBDIRS += fluentui3styleplugin
-        fluentui3styleplugin.depends = FluentUI3Style
+        FluentUI3StylePlugin.file = fluentui3style/plugin/plugin.pro
+        SUBDIRS += FluentUI3StylePlugin
+        FluentUI3StylePlugin.depends = FluentUI3Style
     }
 }
 
 build_gallery {
-    gallery.subdir = examples/Gallery
-    SUBDIRS += gallery
-    gallery.depends = ExWidgets
-    build_library: gallery.depends += FluentUI3Style
+    Gallery.file = Examples/Gallery/Gallery.pro
+    SUBDIRS += Gallery
+    Gallery.depends = ExWidgets
+    build_library: Gallery.depends += FluentUI3Style
 }


### PR DESCRIPTION
## 环境
- Windows / Qt 5.15.2 msvc2019_64（使用 VS2022 工具链）
- qmake + jom 影子构建

## 修复内容
- Gallery 的 lrelease 路径使用正斜杠导致 NMAKE 不执行，改用 shell_path 生成原生路径
- Gallery 缺少 user32 链接，修复 SetWindowPos 链接错误
- 顶层 subdirs 工程写入 FLUENT_BUILD_ROOT 到 .qmake.cache，修复嵌套子项目 bin/lib 输出路径
- 修正顶层工程中样式库、插件、Gallery 的源码路径引用
- README 将不存在的 BUILD_GALLERY 更正为 BUILD_EXAMPLES

## 验证
- 干净影子构建成功
- 产物：Gallery.exe、ExWidgets.dll、FluentUI3Style.dll、FluentUI3StylePlugin.dll
- Gallery 可正常启动，样式插件正常加载