### PR TITLE
fix(style): 限制不确定进度条刷新帧率

### DIFF
--- a/fluentui3style/fluentui3style.cpp
+++ b/fluentui3style/fluentui3style.cpp
@@ -104,6 +104,7 @@ static QMarginsF comboBoxPopupPanelMargins( const QWidget* popup )
 
 static constexpr int ProgressBarThickness         = 4;
 static constexpr int ProgressBarThinThickness     = 3;
+static constexpr int ProgressBarIndeterminateFrameIntervalMs = 16;
 static constexpr int NavigationSettingsSpinRole   = Qt::UserRole + 1001;
 static constexpr int NavigationIconRole           = Qt::UserRole + 1;
 
@@ -5530,6 +5531,27 @@ void FluentUI3Style::drawTreeViewIndicator( const QStyleOptionViewItem* option, 
     }
 }
 
+static void scheduleIndeterminateProgressBarRefresh( const QWidget* widget )
+{
+    if ( !widget )
+    {
+        return;
+    }
+
+    constexpr const char scheduledProperty[] = "_q_fluent_indeterminate_progress_scheduled";
+    auto* target = const_cast<QWidget*>( widget );
+    if ( target->property( scheduledProperty ).toBool() )
+    {
+        return;
+    }
+
+    target->setProperty( scheduledProperty, true );
+    QTimer::singleShot( ProgressBarIndeterminateFrameIntervalMs, target, [ target ]() {
+        target->setProperty( "_q_fluent_indeterminate_progress_scheduled", false );
+        target->update();
+    } );
+}
+
 void FluentUI3Style::drawProgressRing( const QStyleOptionProgressBar* option,
                                        QPainter* painter,
                                        const QWidget* widget,
@@ -5599,7 +5621,7 @@ void FluentUI3Style::drawProgressRing( const QStyleOptionProgressBar* option,
         // Qt angles are CCW; use negative to rotate clockwise.
         startAngle = -360.0 * t;
         spanAngle  = 90.0;
-        const_cast<QWidget*>( widget )->update();
+        scheduleIndeterminateProgressBarRefresh( widget );
     }
     else
     {
@@ -6162,7 +6184,7 @@ void FluentUI3Style::drawControl( ControlElement element, const QStyleOption* op
                     const auto barBegin     = begin * rect.width();
                     const auto barEnd       = end * rect.width();
                     rect = QRectF( QPointF( rect.left() + barBegin, rect.top() ), QPointF( rect.left() + barEnd, rect.bottom() ) );
-                    const_cast<QWidget*>( widget )->update();
+                    scheduleIndeterminateProgressBarRefresh( widget );
                 }
                 else
                 {


### PR DESCRIPTION
## 问题
indeterminate 状态的 QProgressBar（Thin/Thick/Ring）在 paintEvent 中直接调用 update()，
形成 paint -> update -> paint 的无限循环，无帧率限制，会持续占满一个 CPU 核心。

## 修复
- 两处 indeterminate 绘制分支统一改为 16ms 定时刷新（≈60 FPS）
- 同一控件同时只保留一个待执行刷新，避免重复堆积定时器

## 验证
- Qt 5.15.2 MSVC 编译通过
- 不确定进度条动画保持流畅，CPU 占用恢复为正常水平